### PR TITLE
fix rectangle rotation wrong axis

### DIFF
--- a/aplpy/core.py
+++ b/aplpy/core.py
@@ -1423,13 +1423,16 @@ class FITSFigure(Layers, Regions):
             h = height / sy
             a = angle
             transform = self.ax.transData
-
-        x = x - w / 2.
-        y = y - h / 2.
+        
+        xp = x - w / 2.
+        yp = y - h / 2.
+        radeg = np.pi / 180
+        xr = (xp - x)*np.cos((angle)*radeg) - (yp - y)*np.sin((angle)*radeg) + x
+        yr = (xp - x)*np.sin((angle)*radeg) + (yp - y)*np.cos((angle)*radeg) + y
 
         patches = []
-        for i in range(len(x)):
-            patches.append(Rectangle((x[i], y[i]), width=w[i], height=h[i], angle=a[i]))
+        for i in range(len(xr)):
+            patches.append(Rectangle((xr[i], yr[i]), width=w[i], height=h[i], angle=a[i]))
 
         # Due to bugs in matplotlib, we need to pass the patch properties
         # directly to the PatchCollection rather than use match_original.


### PR DESCRIPTION
Rotating a rectangle in show_rectangles works on the wrong axis as described in aplpy/aplpy/pull/327. Fixed by moving the axis of rotation to the rectangle center instead of the image origin.